### PR TITLE
[FEAT] 카카오 로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,21 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// Redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+	// Swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+
+	// OAuth2
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+	// Jwt
+	implementation 'io.jsonwebtoken:jjwt:0.12.6'
+
+	// aws s3
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/festOn/application/user/controller/UserController.java
+++ b/src/main/java/com/example/festOn/application/user/controller/UserController.java
@@ -1,0 +1,32 @@
+package com.example.festOn.application.user.controller;
+
+import com.example.festOn.application.user.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/api/user")
+@RequiredArgsConstructor
+@Tag(name = "User", description = "회원")
+public class UserController {
+
+    private final UserService userService;
+    @Operation(summary = "회원가입", description = "첫 로그인 사용자는 회원가입을 진행합니다.")
+    @PostMapping ("/signup")
+    public ResponseEntity<Long> saveUser(@RequestParam("nickname") String nickname,
+                                         @RequestPart(value = "userImg", required = false) MultipartFile userImg) {
+        Long id = userService.save(nickname, userImg);
+        return ResponseEntity.ok(id);
+    }
+
+    @Operation(summary = "회원 탈퇴", description = "탈퇴시 회원과 관련된 정보가 삭제됩니다.")
+    @DeleteMapping("/delete")
+    public ResponseEntity<Long> deleteUser() {
+        Long id = userService.deleteUser();
+        return ResponseEntity.ok(id);
+    }
+}

--- a/src/main/java/com/example/festOn/application/user/dao/UserRepository.java
+++ b/src/main/java/com/example/festOn/application/user/dao/UserRepository.java
@@ -1,0 +1,10 @@
+package com.example.festOn.application.user.dao;
+
+import com.example.festOn.application.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByKakaoId(String kakaoId);
+}

--- a/src/main/java/com/example/festOn/application/user/entity/User.java
+++ b/src/main/java/com/example/festOn/application/user/entity/User.java
@@ -1,0 +1,35 @@
+package com.example.festOn.application.user.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Setter
+@Entity
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String kakaoId;
+
+    @Column(nullable = false)
+    private String nickname;
+
+    @Column(nullable = false)
+    private String userImg;
+
+    @Column(columnDefinition = "tinyint(1) default 1")
+    private Boolean alarm;
+
+    @Column(columnDefinition = "tinyint(1) default 1")
+    private Boolean nightAlarm;
+
+    @Column(columnDefinition = "tinyint(1) default 1")
+    private Boolean diaryAlarm;
+}

--- a/src/main/java/com/example/festOn/application/user/service/UserService.java
+++ b/src/main/java/com/example/festOn/application/user/service/UserService.java
@@ -1,0 +1,82 @@
+package com.example.festOn.application.user.service;
+
+import com.example.festOn.application.user.dao.UserRepository;
+import com.example.festOn.application.user.entity.User;
+import com.example.festOn.common.auth.service.RefreshTokenService;
+import com.example.festOn.common.s3.service.S3Service;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final S3Service s3Service;
+    private final RefreshTokenService refreshTokenService;
+
+    @Value("${spring.cloud.aws.s3.default-profile-img}")
+    private String defaultImg;
+
+    @Transactional
+    public Long save(String nickname, MultipartFile userImgFile) {
+        String kakaoId = getCurrentUserId();
+        Optional<User> existingUser = userRepository.findByKakaoId(kakaoId);
+
+        String userImg = "";
+        if(userImgFile.isEmpty()) userImg = defaultImg;
+        else userImg = s3Service.uploadFile(userImgFile, "profile");
+
+        if(existingUser.isEmpty()) {
+            User user = existingUser.get();
+            user.setNickname(nickname);
+            user.setUserImg(userImg);
+            return userRepository.save(user).getId();
+        }
+
+        User newUser = User.builder()
+                .kakaoId(kakaoId)
+                .nickname(nickname)
+                .userImg(userImg)
+                .alarm(true)
+                .diaryAlarm(true)
+                .nightAlarm(true)
+                .build();
+
+        return userRepository.save(newUser).getId();
+    }
+
+    @Transactional
+    public Long deleteUser() {
+        User user = getCurrentUser();
+        userRepository.delete(user);
+        refreshTokenService.deleteRefreshToken(user.getKakaoId());
+        return user.getId();
+    }
+
+    public User findByKakaoId(String kakaoId) {
+        return userRepository.findByKakaoId(kakaoId).orElse(null);
+    }
+
+    public User getCurrentUser() {
+        String kakaoId = getCurrentUserId();
+        return userRepository.findByKakaoId(kakaoId)
+                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
+    }
+
+    public String getCurrentUserId() {
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        if(principal instanceof OAuth2User) {
+            return String.valueOf(((OAuth2User) principal).getAttributes().get("id"));
+        } else {
+            return principal.toString();
+        }
+    }
+}

--- a/src/main/java/com/example/festOn/common/auth/api/TokenController.java
+++ b/src/main/java/com/example/festOn/common/auth/api/TokenController.java
@@ -1,0 +1,2 @@
+package com.example.festOn.common.auth.api;public class TokenController {
+}

--- a/src/main/java/com/example/festOn/common/auth/api/TokenController.java
+++ b/src/main/java/com/example/festOn/common/auth/api/TokenController.java
@@ -1,2 +1,108 @@
-package com.example.festOn.common.auth.api;public class TokenController {
+package com.example.festOn.common.auth.api;
+
+import com.example.festOn.common.auth.jwt.JwtTokenProvider;
+import com.example.festOn.common.auth.service.RefreshTokenService;
+import com.example.festOn.common.config.UrlProperties;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/token")
+@Tag(name = "Token", description = "토큰")
+public class TokenController {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenService refreshTokenService;
+    private final UrlProperties urlProperties;
+
+    @Operation(summary = "액세스 토큰 재발급", description = "RefreshToken을 통해 엑세스 토큰 발급")
+    @PostMapping("/reissue")
+    public ResponseEntity<?> refreshAccessToken(HttpServletRequest request, HttpServletResponse response) {
+        String refreshToken = extractTokenFromCookies(request);
+        if(refreshToken == null) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("No Refresh Token provided");
+        }
+
+        if(!jwtTokenProvider.validateToken(refreshToken)) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid or Expired Refresh Token");
+        }
+
+        String userId = jwtTokenProvider.getUserIdFromToken(refreshToken);
+
+        String savedRefreshToken = refreshTokenService.getRefreshToken(userId);
+        if(savedRefreshToken == null || !savedRefreshToken.equals(refreshToken)) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Refresh Token mismatch");
+        }
+
+        String newAccessToken = jwtTokenProvider.createToken(userId);
+        addAccessTokenToCookie(response, newAccessToken);
+
+        return ResponseEntity.ok("Access Token reissued successfully");
+    }
+
+    @Operation(summary = "로그아웃")
+    @PostMapping("/logout")
+    public ResponseEntity<String> logout(HttpServletRequest request, HttpServletResponse response) {
+        String refreshToken = extractTokenFromCookies(request);
+
+        if(refreshToken != null && jwtTokenProvider.validateToken(refreshToken)) {
+            String kakaoId = jwtTokenProvider.getUserIdFromToken(refreshToken);
+            refreshTokenService.deleteRefreshToken(kakaoId);
+
+            deleteCookie(response, "AccessToken");
+            deleteCookie(response, "RefreshToken");
+
+            return ResponseEntity.ok("Successfully logged out");
+        }
+
+        return ResponseEntity.status(HttpServletResponse.SC_UNAUTHORIZED).body("Invalid token");
+    }
+
+    private String extractTokenFromCookies(HttpServletRequest request) {
+        if(request.getCookies() != null) {
+            for(Cookie cookie : request.getCookies()) {
+                if(cookie.getValue().equals("RefreshToken")) {
+                    return cookie.getValue();
+                }
+            }
+        }
+        return null;
+    }
+
+    private void addAccessTokenToCookie(HttpServletResponse response, String accessToken) {
+        ResponseCookie cookie = ResponseCookie.from("AccessToken", accessToken)
+                .maxAge((int) jwtTokenProvider.getValidityInMilliseconds() / 1000)
+                .path("/")
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("None")
+                .domain(urlProperties.getDomain())
+                .build();
+
+        response.addHeader("Set-Cookie", cookie.toString());
+    }
+
+    private void deleteCookie(HttpServletResponse response, String cookieName) {
+        ResponseCookie cookie = ResponseCookie.from(cookieName, "")
+                .maxAge(0)
+                .path("/")
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("None")
+                .domain(urlProperties.getDomain())
+                .build();
+
+        response.addHeader("Set-Cookie", cookie.toString());
+    }
 }

--- a/src/main/java/com/example/festOn/common/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/festOn/common/auth/filter/JwtAuthenticationFilter.java
@@ -1,2 +1,63 @@
-package com.example.festOn.common.auth.filter;public class JwtAuthenticationFilter {
+package com.example.festOn.common.auth.filter;
+
+import com.example.festOn.common.auth.jwt.JwtTokenProvider;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String accessToken =getTokenFromRequest(request);
+        if(accessToken != null) {
+            if (jwtTokenProvider.validateToken(accessToken)) {
+                if (jwtTokenProvider.isTokenExpired(accessToken)) {
+                    // Access Token이 만료된 경우
+                    response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Access token expired");
+                    return;
+                } else {
+                    // Access Token이 만료되지 않은 경우
+                    setAuthenicationContext(accessToken, request);
+                }
+            } else {
+                // Access Token이 유효하지 않은 경우
+                response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Invalid Access token");
+                return;
+            }
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    private void setAuthenicationContext(String token, HttpServletRequest request) {
+        String userId = jwtTokenProvider.getUserIdFromToken(token);
+
+        UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(userId, null, null);
+
+        authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    private String getTokenFromRequest(HttpServletRequest request) {
+        if(request.getCookies() != null) {
+            for(Cookie cookie : request.getCookies()) {
+                if(cookie.getName().equals("AccessToken")) {
+                    return cookie.getValue();
+                }
+            }
+        }
+        return null;
+    }
 }

--- a/src/main/java/com/example/festOn/common/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/festOn/common/auth/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,2 @@
+package com.example.festOn.common.auth.filter;public class JwtAuthenticationFilter {
+}

--- a/src/main/java/com/example/festOn/common/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/example/festOn/common/auth/jwt/JwtTokenProvider.java
@@ -1,2 +1,96 @@
-package com.example.festOn.common.auth.jwt;public class JwtTokenProvider {
+package com.example.festOn.common.auth.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.security.Keys;
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.util.Date;
+
+@Getter
+@Component
+public class JwtTokenProvider {
+
+    @Value("${spring.jwt.secret-key}")
+    private String secretKey;
+
+    @Value("${spring.jwt.expiration}")
+    private long validityInMilliseconds;
+
+    @Value("${spring.jwt.refresh-expiration}")
+    private long refreshValidityInMilliseconds;
+
+    // SecretKey 생성
+    private SecretKey getSigningKey() {
+        return Keys.hmacShaKeyFor(secretKey.getBytes());
+    }
+
+    // 액세스 토큰 생성
+    public String createToken(String kakaoId) {
+        Claims claims = Jwts.claims().subject(kakaoId).build();
+        Date now = new Date();
+        Date validity = new Date(now.getTime() + validityInMilliseconds);
+
+        return Jwts.builder()
+                .claims(claims)
+                .issuedAt(now)
+                .expiration(validity)
+                .signWith(getSigningKey())
+                .compact();
+    }
+
+    // 리프레시 토큰 생성
+    public String createRefreshToken(String kakaoId) {
+        Claims claims = Jwts.claims().subject(kakaoId).build();
+        Date now = new Date();
+        Date validity = new Date(now.getTime() + refreshValidityInMilliseconds);
+
+        return Jwts.builder()
+                .claims(claims)
+                .issuedAt(now)
+                .expiration(validity)
+                .signWith(getSigningKey())
+                .compact();
+    }
+
+    // JWT 토큰 검증
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parser().verifyWith(getSigningKey())
+                    .build()
+                    .parseSignedClaims(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    // JWT 토큰 만료 여부 확인
+    public boolean isTokenExpired(String token) {
+        try {
+            Date expiration = Jwts.parser()
+                    .verifyWith(getSigningKey())
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload()
+                    .getExpiration();
+            return expiration.before(new Date());
+        } catch (JwtException e) {
+            return true;
+        }
+    }
+
+    // JWT 토큰에서 사용자 ID 추출
+    public String getUserIdFromToken(String token) {
+        return Jwts.parser()
+                .verifyWith(getSigningKey())
+                .build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .getSubject();
+    }
 }

--- a/src/main/java/com/example/festOn/common/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/example/festOn/common/auth/jwt/JwtTokenProvider.java
@@ -1,0 +1,2 @@
+package com.example.festOn.common.auth.jwt;public class JwtTokenProvider {
+}

--- a/src/main/java/com/example/festOn/common/auth/service/RefreshTokenService.java
+++ b/src/main/java/com/example/festOn/common/auth/service/RefreshTokenService.java
@@ -1,2 +1,39 @@
-package com.example.festOn.common.auth.service;public class RefreshTokenService {
+package com.example.festOn.common.auth.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@Slf4j
+@Service
+public class RefreshTokenService {
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public RefreshTokenService(RedisTemplate<String, Object> redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    // Refresh Token 저장
+    public void saveRefreshToken(String kakaoId, String refreshToken, long expiration) {
+        try {
+            ValueOperations<String, Object> valueOperations = redisTemplate.opsForValue();
+            valueOperations.set(kakaoId, refreshToken, Duration.ofMillis(expiration));
+        } catch (Exception e) {
+            log.error("리프레시 토큰 저장 실패: {}", e.getMessage());
+        }
+    }
+
+    // Refresh Token 조회
+    public String getRefreshToken(String kakaoId) {
+        ValueOperations<String, Object> valueOperations = redisTemplate.opsForValue();
+        return (String) valueOperations.get(kakaoId);
+    }
+
+    // Refresh Token 삭제
+    public void deleteRefreshToken(String kakaoId) {
+        redisTemplate.delete(kakaoId);
+    }
 }

--- a/src/main/java/com/example/festOn/common/auth/service/RefreshTokenService.java
+++ b/src/main/java/com/example/festOn/common/auth/service/RefreshTokenService.java
@@ -1,0 +1,2 @@
+package com.example.festOn.common.auth.service;public class RefreshTokenService {
+}

--- a/src/main/java/com/example/festOn/common/config/AwsS3Config.java
+++ b/src/main/java/com/example/festOn/common/config/AwsS3Config.java
@@ -1,8 +1,31 @@
 package com.example.festOn.common.config;
 
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-public class BucketConfig {
+public class AwsS3Config {
+    @Value("${spring.cloud.aws.credentials.access-key}")
+    private String accessKey;
 
+    @Value("${spring.cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${spring.cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 amazonS3Client() {
+        BasicAWSCredentials basicAWSCredentials = new BasicAWSCredentials(accessKey, secretKey);
+        return AmazonS3ClientBuilder
+                .standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(basicAWSCredentials))
+                .build();
+    }
 }

--- a/src/main/java/com/example/festOn/common/config/AwsS3Config.java
+++ b/src/main/java/com/example/festOn/common/config/AwsS3Config.java
@@ -1,0 +1,8 @@
+package com.example.festOn.common.config;
+
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class BucketConfig {
+
+}

--- a/src/main/java/com/example/festOn/common/config/CorsProperties.java
+++ b/src/main/java/com/example/festOn/common/config/CorsProperties.java
@@ -1,2 +1,19 @@
-package com.example.festOn.common.config;public class CorsProperties {
+package com.example.festOn.common.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Getter
+@Setter
+@Configuration
+@ConfigurationProperties(prefix = "cors")
+public class CorsProperties {
+    private List<String> allowedOrigins;
+    private List<String> allowedMethods;
+    private List<String> allowedHeaders;
+    private Boolean allowCredentials;
 }

--- a/src/main/java/com/example/festOn/common/config/CorsProperties.java
+++ b/src/main/java/com/example/festOn/common/config/CorsProperties.java
@@ -1,0 +1,2 @@
+package com.example.festOn.common.config;public class CorsProperties {
+}

--- a/src/main/java/com/example/festOn/common/config/RedisConfig.java
+++ b/src/main/java/com/example/festOn/common/config/RedisConfig.java
@@ -1,2 +1,38 @@
-package com.example.festOn.common.config;public class RedisConfig {
+package com.example.festOn.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.data.redis.port}")
+    private int redisPort;
+
+    @Value("${spring.data.redis.password}")
+    private String redisPassword;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        LettuceConnectionFactory lettuceConnectionFactory = new LettuceConnectionFactory(redisHost, redisPort);
+        lettuceConnectionFactory.setPassword(redisPassword);
+        return lettuceConnectionFactory;
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        return redisTemplate;
+    }
 }

--- a/src/main/java/com/example/festOn/common/config/RedisConfig.java
+++ b/src/main/java/com/example/festOn/common/config/RedisConfig.java
@@ -1,0 +1,2 @@
+package com.example.festOn.common.config;public class RedisConfig {
+}

--- a/src/main/java/com/example/festOn/common/config/SecurityConfig.java
+++ b/src/main/java/com/example/festOn/common/config/SecurityConfig.java
@@ -1,0 +1,2 @@
+package com.example.festOn.common.config;public class SecurityConfig {
+}

--- a/src/main/java/com/example/festOn/common/config/SecurityConfig.java
+++ b/src/main/java/com/example/festOn/common/config/SecurityConfig.java
@@ -1,2 +1,127 @@
-package com.example.festOn.common.config;public class SecurityConfig {
+package com.example.festOn.common.config;
+
+import com.example.festOn.application.user.service.UserService;
+import com.example.festOn.common.auth.filter.JwtAuthenticationFilter;
+import com.example.festOn.common.auth.jwt.JwtTokenProvider;
+import com.example.festOn.common.auth.service.RefreshTokenService;
+import com.example.festOn.common.oauth2.handler.CustomAuthenticationSuccessHander;
+import com.example.festOn.common.oauth2.service.CustomOAuth2UserService;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.oauth2.client.endpoint.DefaultAuthorizationCodeTokenResponseClient;
+import org.springframework.security.oauth2.client.endpoint.OAuth2AccessTokenResponseClient;
+import org.springframework.security.oauth2.client.endpoint.OAuth2AuthorizationCodeGrantRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final RefreshTokenService refreshTokenService;
+    private final UserService userService;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final CorsProperties corsProperties;
+    private final UrlProperties urlProperties;
+
+    private static final String[] ALLOWED_URL = {
+            "/",
+            "/index.html",
+            "/swagger-ui.html",
+            "/swagger-ui/**",
+            "/api-docs",
+            "/api-docs/**",
+            "/api/token/reissue",
+            "/oauth/**",
+            "/oauth2/**",
+            "/oauth/login/kakao",
+            "/login-failure",
+            "/error"
+    };
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception{
+        http
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+                .csrf(CsrfConfigurer::disable)
+                .headers(httpSecurityHeadersConfigurer ->
+                        httpSecurityHeadersConfigurer.frameOptions(
+                                HeadersConfigurer.FrameOptionsConfig::disable)
+                        )
+                .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class)
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(ALLOWED_URL).permitAll()
+                        .anyRequest().authenticated()
+                )
+                .oauth2Login(oauth2 -> oauth2
+                        .loginPage("/oauth2/authorization/kakao")
+                        .authorizationEndpoint(authorization -> authorization
+                                .baseUri("/oauth2/authorization")
+                        )
+                        .tokenEndpoint(token -> token
+                                .accessTokenResponseClient(kakaoAccessTokenResponseClient())
+                        )
+                        .userInfoEndpoint(userInfo -> userInfo
+                                .userService(oAuth2UserService())
+                        )
+                        .successHandler(customAuthenticationSuccessHander())
+                        .failureHandler(new SimpleUrlAuthenticationFailureHandler("/login-failure"))
+                )
+                .exceptionHandling(exceptionHandling -> exceptionHandling
+                        .authenticationEntryPoint((request, response, authException) -> {
+                            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized: Access token is invalid or expired");
+                        })
+                );
+        return http.build();
+    }
+
+    @Bean
+    CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(corsProperties.getAllowedOrigins());
+        configuration.setAllowedMethods(corsProperties.getAllowedMethods());
+        configuration.setAllowedHeaders(corsProperties.getAllowedHeaders());
+        configuration.setAllowCredentials(corsProperties.getAllowCredentials());
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+
+    @Bean
+    public OAuth2UserService<OAuth2UserRequest, OAuth2User> oAuth2UserService() {
+        return new CustomOAuth2UserService(userService);
+    }
+
+    @Bean
+    public CustomAuthenticationSuccessHander customAuthenticationSuccessHander() {
+        return new CustomAuthenticationSuccessHander(jwtTokenProvider, refreshTokenService, urlProperties);
+    }
+
+    @Bean
+    public OAuth2AccessTokenResponseClient<OAuth2AuthorizationCodeGrantRequest> kakaoAccessTokenResponseClient() {
+        return new DefaultAuthorizationCodeTokenResponseClient();
+    }
+
+    @Bean
+    public JwtAuthenticationFilter jwtAuthenticationFilter() {
+        return new JwtAuthenticationFilter(jwtTokenProvider);
+    }
 }

--- a/src/main/java/com/example/festOn/common/config/SwaggerConfig.java
+++ b/src/main/java/com/example/festOn/common/config/SwaggerConfig.java
@@ -1,2 +1,36 @@
-package com.example.festOn.common.config;public class SwaggerConfig {
+package com.example.festOn.common.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .components(new Components().addSecuritySchemes("bearerAuth", bearerSecurityScheme()))
+                .info(apiInfo())
+                .addSecurityItem(new SecurityRequirement().addList("bearerAuth"));
+    }
+
+    private SecurityScheme bearerSecurityScheme() {
+        return new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+                .in(SecurityScheme.In.HEADER)
+                .name("Authorization");
+    }
+
+    private Info apiInfo() {
+        return new Info()
+                .title("Fest ON")
+                .description("Fest ON API DOCS")
+                .version("1.0.0");
+    }
 }

--- a/src/main/java/com/example/festOn/common/config/SwaggerConfig.java
+++ b/src/main/java/com/example/festOn/common/config/SwaggerConfig.java
@@ -1,0 +1,2 @@
+package com.example.festOn.common.config;public class SwaggerConfig {
+}

--- a/src/main/java/com/example/festOn/common/config/UrlProperties.java
+++ b/src/main/java/com/example/festOn/common/config/UrlProperties.java
@@ -1,2 +1,21 @@
-package com.example.festOn.common.config;public class UrlProperties {
+package com.example.festOn.common.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+public class UrlProperties {
+
+    @Value("${spring.url.redirectUrl.signUp}")
+    private String signUpUrl;
+
+    @Value("${spring.url.redirectUrl.main}")
+    private String mainUrl;
+
+    @Value("${spring.url.domain}")
+    private String domain;
 }

--- a/src/main/java/com/example/festOn/common/config/UrlProperties.java
+++ b/src/main/java/com/example/festOn/common/config/UrlProperties.java
@@ -1,0 +1,2 @@
+package com.example.festOn.common.config;public class UrlProperties {
+}

--- a/src/main/java/com/example/festOn/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/festOn/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,2 @@
+package com.example.festOn.common.exception;public class GlobalExceptionHandler {
+}

--- a/src/main/java/com/example/festOn/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/festOn/common/exception/GlobalExceptionHandler.java
@@ -1,2 +1,17 @@
-package com.example.festOn.common.exception;public class GlobalExceptionHandler {
+package com.example.festOn.common.exception;
+
+import com.example.festOn.common.oauth2.exception.CustomJwtException;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(CustomJwtException.class)
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    public String handleCustomJwtException(CustomJwtException e) {
+        return e.getMessage();
+    }
 }

--- a/src/main/java/com/example/festOn/common/oauth2/exception/CustomJwtException.java
+++ b/src/main/java/com/example/festOn/common/oauth2/exception/CustomJwtException.java
@@ -1,4 +1,4 @@
-package com.example.festOn.common.exception;
+package com.example.festOn.common.oauth2.exception;
 
 public class CustomJwtException extends RuntimeException {
 

--- a/src/main/java/com/example/festOn/common/oauth2/exception/CustomJwtException.java
+++ b/src/main/java/com/example/festOn/common/oauth2/exception/CustomJwtException.java
@@ -1,0 +1,8 @@
+package com.example.festOn.common.exception;
+
+public class CustomJwtException extends RuntimeException {
+
+    public CustomJwtException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/festOn/common/oauth2/handler/CustomAuthenticationSuccessHander.java
+++ b/src/main/java/com/example/festOn/common/oauth2/handler/CustomAuthenticationSuccessHander.java
@@ -1,0 +1,2 @@
+package com.example.festOn.common.oauth2.handler;public class CustomAuthenticationSuccessHander {
+}

--- a/src/main/java/com/example/festOn/common/oauth2/handler/CustomAuthenticationSuccessHander.java
+++ b/src/main/java/com/example/festOn/common/oauth2/handler/CustomAuthenticationSuccessHander.java
@@ -1,2 +1,61 @@
-package com.example.festOn.common.oauth2.handler;public class CustomAuthenticationSuccessHander {
+package com.example.festOn.common.oauth2.handler;
+
+import com.example.festOn.common.auth.jwt.JwtTokenProvider;
+import com.example.festOn.common.auth.service.RefreshTokenService;
+import com.example.festOn.common.config.UrlProperties;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseCookie;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAuthenticationSuccessHander implements AuthenticationSuccessHandler {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenService refreshTokenService;
+    private final UrlProperties urlProperties;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+        OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
+
+        String kakaoId = oAuth2User.getAttribute("id").toString();
+        boolean isFirstLogin = Boolean.TRUE.equals(oAuth2User.getAttribute("isFirstLogin"));
+
+        String accessToken = jwtTokenProvider.createToken(kakaoId);
+        String refreshToken = refreshTokenService.getRefreshToken(kakaoId);
+
+        if(refreshToken == null || jwtTokenProvider.isTokenExpired(refreshToken)) {
+            refreshToken = jwtTokenProvider.createRefreshToken(kakaoId);
+            refreshTokenService.saveRefreshToken(kakaoId, refreshToken, jwtTokenProvider.getRefreshValidityInMilliseconds());
+        }
+
+        addCookie(response, "AccessToken", accessToken, jwtTokenProvider.getValidityInMilliseconds());
+        addCookie(response, "RefreshToken", refreshToken, jwtTokenProvider.getRefreshValidityInMilliseconds());
+
+        String rediretUrl = isFirstLogin ? urlProperties.getSignUpUrl() : urlProperties.getMainUrl();
+
+        response.sendRedirect(rediretUrl);
+    }
+
+    private void addCookie(HttpServletResponse response, String name, String value, long maxAgeMillis) {
+        ResponseCookie cookie = ResponseCookie.from(name, value)
+                .maxAge(maxAgeMillis / 1000)
+                .path("/")
+                .secure(true)
+                .httpOnly(true)
+                .sameSite("None")
+                .domain(urlProperties.getDomain())
+                .build();
+
+        response.addHeader("Set-Cookie", cookie.toString());
+    }
 }

--- a/src/main/java/com/example/festOn/common/oauth2/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/example/festOn/common/oauth2/service/CustomOAuth2UserService.java
@@ -1,2 +1,54 @@
-package com.example.festOn.common.oauth2.service;public class CustomOAuth2UserService {
+package com.example.festOn.common.oauth2.service;
+
+import com.example.festOn.application.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+    private final UserService userService;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        try {
+            OAuth2UserService<OAuth2UserRequest, OAuth2User> delegate = new DefaultOAuth2UserService();
+            OAuth2User oAuth2User = delegate.loadUser(userRequest);
+
+            Map<String, Object> attributes = oAuth2User.getAttributes();
+
+            String kakaoId = String.valueOf(attributes.get("id"));
+
+            boolean isFirstLogin = userService.findByKakaoId(kakaoId) == null;
+
+            Map<String, Object> additionalAttributes = new HashMap<>(attributes);
+            additionalAttributes.put("isFirstLogin", isFirstLogin);
+
+            return new DefaultOAuth2User(
+                    Collections.singleton(new SimpleGrantedAuthority("ROLE_USER")),
+                    additionalAttributes,
+                    "id"
+            );
+        } catch (OAuth2AuthenticationException e) {
+            log.warn("OAuth2 인증 실패: {}", e.getMessage());
+            throw e;
+        } catch (Exception e) {
+            log.warn("사용자 정보 가져오기 실패: {}", e.getMessage());
+            throw e;
+        }
+    }
 }

--- a/src/main/java/com/example/festOn/common/oauth2/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/example/festOn/common/oauth2/service/CustomOAuth2UserService.java
@@ -1,0 +1,2 @@
+package com.example.festOn.common.oauth2.service;public class CustomOAuth2UserService {
+}

--- a/src/main/java/com/example/festOn/common/s3/service/S3Service.java
+++ b/src/main/java/com/example/festOn/common/s3/service/S3Service.java
@@ -1,0 +1,2 @@
+package com.example.festOn.common.s3.service;public class S3Service {
+}

--- a/src/main/java/com/example/festOn/common/s3/service/S3Service.java
+++ b/src/main/java/com/example/festOn/common/s3/service/S3Service.java
@@ -1,2 +1,89 @@
-package com.example.festOn.common.s3.service;public class S3Service {
+package com.example.festOn.common.s3.service;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class S3Service {
+
+    private final AmazonS3 amazonS3Client;
+
+    @Value("${spring.cloud.aws.s3.bucket-name}")
+    private String bucket;
+
+    @Value("${spring.cloud.aws.s3.default-profile-img}")
+    private String defaultImg;
+
+    public String getUuidFileName(String fileName) {
+        String ext = fileName.substring(fileName.lastIndexOf(".") + 1);
+        return UUID.randomUUID().toString() + "." + ext;
+    }
+
+    //NOTICE: filePath의 맨 앞에 /는 안붙여도됨. ex) history/images
+    public String uploadFile(MultipartFile multipartFile, String filePath) {
+
+        String originalFileName = multipartFile.getOriginalFilename();
+        String uploadFileName = getUuidFileName(originalFileName);
+        String uploadFileUrl = "";
+
+        ObjectMetadata objectMetadata = new ObjectMetadata();
+        objectMetadata.setContentLength(multipartFile.getSize());
+        objectMetadata.setContentType(multipartFile.getContentType());
+
+        try (InputStream inputStream = multipartFile.getInputStream()) {
+
+            String keyName = filePath + "/" + uploadFileName;
+
+            // S3에 폴더 및 파일 업로드
+            amazonS3Client.putObject(
+                    new PutObjectRequest(bucket, keyName, inputStream, objectMetadata)
+                            .withCannedAcl(CannedAccessControlList.PublicRead));
+
+            // AWS S3 업로드한 파일 URL 생성
+            uploadFileUrl = amazonS3Client.getUrl(bucket, keyName).toString();
+
+        } catch (IOException e) {
+            log.error("파일 업로드 중 오류 발생: {}", e.getMessage());
+            throw new RuntimeException("파일 업로드 실패");
+        }
+
+        return uploadFileUrl; // 업로드된 파일의 S3 URL 반환
+    }
+
+    // 이미지 수정으로 인해 기존 이미지 삭제 메소드
+    public void deleteImage(String ImgUrl) {
+        String splitStr = ".amazonaws.com/";
+        String fileName = ImgUrl.substring(ImgUrl.lastIndexOf(splitStr) + splitStr.length());
+
+        // 기본 프로필 이미지가 아닐 때, 삭제
+        if (!ImgUrl.equals(defaultImg)) {
+            amazonS3Client.deleteObject(new DeleteObjectRequest(bucket, fileName));
+            log.info("이미지 삭제 완료: {}", fileName);
+        }
+    }
+
+    // 게시글 삭제 시, 옵션이미지 삭제
+    public void deleteImg(String ImgUrl) {
+        String splitStr = ".amazonaws.com/";
+        String fileName = ImgUrl.substring(ImgUrl.lastIndexOf(splitStr) + splitStr.length());
+
+        amazonS3Client.deleteObject(new DeleteObjectRequest(bucket, fileName));
+        log.info("이미지 삭제 완료: {}", fileName);
+    }
 }


### PR DESCRIPTION
## ✨ 개요
사용자 관련 기능, JWT 인증 시스템, 공통 설정, 예외 처리, OAuth2 처리, S3 서비스 기능을 추가하였습니다.

## 변경 사항
- **사용자 관련 기능**:
  - 회원 가입 및 회원 삭제 api 구현
- **인증 시스템**:
  - 엑세스 토큰 재발급, 로그아웃 기능 api 구현
  - Redis에 리프레시 토큰 저장, 조회, 삭제 기능 구현
  - JWT 토큰 생성, 만료, 검증 기능 구현
  - 쿠키 "AccessToken", "RefreshToken" key로 JWT 전달
- **공통 설정**:
  - AWS, Redis, 보안, Swagger 공통 설정 파일 추가
- **예외 처리**:
  - 글로벌 예외 처리 기능 추가 
- **OAuth2 관련**:
  - OAuth2 인증 처리와 관련된 커스텀 예외 및 핸들러 추가
  - 첫 로그인 사용자일시 회원가입 페이지로, 아니라면 메인 페이지로 redirect
- **S3 서비스**:
  - S3 파일 업로드 및 삭제 기능 추가
  - 파일 형식은 file/image.png 형식으로 저장
- **빌드 파일**:
  - `build.gradle` 파일 업데이트

## 🙋🏻 PR 유형

- [x]  기능 구현

## ✍🏻 To Reviewers
jwt를 쿠키에 담아 전달하는 방식으로 구현했습니다. 테스트해볼 방법이 없어 프론트와 통신 후 수정하겠습니다.
