### PR TITLE
bug fix: 도커 파일 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /app
 # Gradle 파일을 복사하고 종속성 다운로드
 COPY build.gradle settings.gradle ./
 COPY src ./src
-RUN gradle build --no-daemon  # Gradle 빌드 실행
+RUN gradle build -x test --no-daemon  # 테스트를 건너뛰고 Gradle 빌드 실행
 
 # 2. 프로덕션 이미지를 생성하는 단계
 FROM openjdk:17-jdk-slim


### PR DESCRIPTION
gradle 빌드 시에 테스트 파일을 추가하지 않도록 도커 파일을 수정했습니다.
`RUN gradle build -x test --no-daemon`